### PR TITLE
Update python_version 3.13

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,11 @@ repos:
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
+  - repo: https://github.com/phantomcyber/soar-app-linter
+    rev: 0.1.0
+    hooks:
+      - id: soar-app-linter
+        args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
@@ -55,7 +60,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.0.4
+    rev: v2.0.9
     hooks:
       - id: build-docs
         language: python

--- a/adldap.json
+++ b/adldap.json
@@ -17,7 +17,7 @@
     "min_phantom_version": "6.3.0",
     "fips_compliant": true,
     "app_wizard_version": "1.0.2",
-    "python_version": "3.9",
+    "python_version": "3.9, 3.13",
     "latest_tested_versions": [
         "ldap3 on 25/10/2024"
     ],

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13
- Replace `.pre-commit-config.yaml` with latest template from dev-cicd-tools

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions-3.13-2.0`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions-3.13-2.0)